### PR TITLE
Load backtest data from MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ If no symbols are provided the script will read them from the `symbols` table in
 
 ## Backtesting
 
-This repo includes a simple backtest runner. Price data is expected as CSV files in `data/` with the columns `timestamp,open,high,low,close,spread`.
+This repo includes a simple backtest runner. Price data is fetched from the
+MySQL table `mark1`. Connection settings are read from the environment variables
+`DB_HOST`, `DB_USER`, `DB_PASSWORD` and `DB_NAME` or can be supplied via CLI
+flags.
 Run a strategy with:
 
 ```sh
-python backtests/run_backtest.py --symbol BTCUSDT \
-       --strategy vol_breakout --start 2023-01-01 --end 2023-06-01
+python -m backtests.run_backtest --symbol BTCUSDT \
+       --strategy vol_breakout --start 2024-11-20 --end 2024-11-27 \
+       --db-user <user> --db-pass <pass>
 ```
 

--- a/backtests/run_backtest.py
+++ b/backtests/run_backtest.py
@@ -1,14 +1,25 @@
 import argparse
+import os
 import pandas as pd
 from importlib import import_module
 from backtests.core import cagr, max_drawdown, sharpe_ratio, win_rate, payoff_ratio
+from run_ingest import db_conn
 
 
-def load_data(symbol: str, start: str, end: str) -> pd.DataFrame:
-    path = f"data/{symbol}.csv"
-    df = pd.read_csv(path, parse_dates=['timestamp'])
-    df.set_index('timestamp', inplace=True)
-    return df.loc[start:end]
+def load_data(conn, symbol: str, start: str, end: str) -> pd.DataFrame:
+    """Load OHLC data from MySQL mark1 table."""
+    query = (
+        "SELECT startTime AS ts, open, high, low, close "
+        "FROM mark1 "
+        "WHERE symbol=%s AND startTime BETWEEN %s AND %s "
+        "ORDER BY startTime"
+    )
+    start_ts = int(pd.Timestamp(start).timestamp() * 1000)
+    end_ts = int(pd.Timestamp(end).timestamp() * 1000)
+    df = pd.read_sql(query, conn, params=(symbol, start_ts, end_ts))
+    df["ts"] = pd.to_datetime(df.ts, unit="ms")
+    df.set_index("ts", inplace=True)
+    return df[["open", "high", "low", "close"]].astype(float)
 
 
 def main():
@@ -17,9 +28,24 @@ def main():
     parser.add_argument('--strategy', required=True)
     parser.add_argument('--start', required=True)
     parser.add_argument('--end', required=True)
+    parser.add_argument('--db-user')
+    parser.add_argument('--db-pass')
+    parser.add_argument('--db-host')
+    parser.add_argument('--db-name')
     args = parser.parse_args()
 
-    df = load_data(args.symbol, args.start, args.end)
+    if args.db_user:
+        os.environ['DB_USER'] = args.db_user
+    if args.db_pass:
+        os.environ['DB_PASSWORD'] = args.db_pass
+    if args.db_host:
+        os.environ['DB_HOST'] = args.db_host
+    if args.db_name:
+        os.environ['DB_NAME'] = args.db_name
+
+    conn = db_conn()
+    df = load_data(conn, args.symbol, args.start, args.end)
+    conn.close()
 
     module = import_module(f"strategies.{args.strategy}")
     cls = getattr(module, ''.join([p.capitalize() for p in args.strategy.split('_')]))


### PR DESCRIPTION
## Summary
- fetch backtest candles from MySQL instead of CSV
- allow DB credentials via flags or environment variables
- document new backtest usage with MySQL

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m backtests.run_backtest --help` *(fails: ModuleNotFoundError: No module named 'pandas')*