### PR TITLE
Implement portfolio backtester and funding carry strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ python -m backtests.run_backtest \
        --symbol BTCUSDT \
        --strategy vol_breakout \
        --start 2024-11-20 \
-       --end   2024-11-27
+       --end   2024-11-27 \
+       --risk-mult 1.0
 ```
 
 
@@ -64,3 +65,20 @@ python run_grid.py --start 2024-02-01 --end 2024-05-01 --symbols BTCUSDT ETHUSDT
 
 Results are saved to `grid_results.csv`.
 
+
+## Funding-Carry Strategy
+
+`funding_carry` trades when the predicted funding rate deviates from spot. The prediction is clamped to ±0.75% and positions are opened when it exceeds ±0.3% with at least five minutes to the next funding event.
+
+## Portfolio Backtest Usage
+
+Multiple strategies can be combined with `run_portfolio.py`:
+
+```sh
+python run_portfolio.py \
+       --symbols BTCUSDT ETHUSDT \
+       --strategies vol_breakout funding_carry \
+       --start 2024-02-01 --end 2024-05-01
+```
+
+The script prints metrics for each strategy and for the total portfolio.

--- a/run_ingest.py
+++ b/run_ingest.py
@@ -3,22 +3,12 @@ import time
 import argparse
 import logging
 import requests
-import pymysql
 from tqdm import tqdm
+from utils.db import db_conn
 
 BASE_URL = "https://api.bybit.com"
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
-
-def db_conn():
-    return pymysql.connect(
-        host=os.getenv("DB_HOST", "localhost"),
-        user=os.getenv("DB_USER", "root"),
-        password=os.getenv("DB_PASSWORD", ""),
-        database=os.getenv("DB_NAME", "bybit"),
-        port=int(os.getenv("DB_PORT", 3306)),
-        autocommit=False
-    )
 
 def create_tables(conn):
     """Create or update required MySQL tables."""

--- a/run_portfolio.py
+++ b/run_portfolio.py
@@ -1,0 +1,47 @@
+import argparse
+from importlib import import_module
+
+import pandas as pd
+
+from backtests.run_backtest import load_data
+from backtests.core import run_portfolio, cagr, max_drawdown, sharpe_ratio
+from utils.db import db_conn
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run portfolio backtest")
+    parser.add_argument("--symbols", nargs="+", required=True)
+    parser.add_argument("--strategies", nargs="+", required=True)
+    parser.add_argument("--start", required=True)
+    parser.add_argument("--end", required=True)
+    args = parser.parse_args()
+
+    conn = db_conn()
+    data = {sym: load_data(conn, sym, args.start, args.end, with_index=True) for sym in args.symbols}
+    conn.close()
+
+    strategy_items = []
+    for strat_name in args.strategies:
+        module = import_module(f"strategies.{strat_name}")
+        cls = getattr(module, "".join([p.capitalize() for p in strat_name.split("_")]))
+        for sym in args.symbols:
+            strat = cls()
+            strategy_items.append((strat_name, sym, strat, data[sym]))
+
+    summary, portfolio_eq, _ = run_portfolio(strategy_items)
+
+    for strat in summary["strategy"].unique():
+        sub = summary[summary["strategy"] == strat]
+        print(f"Strategy {strat}:")
+        print(sub.to_string(index=False))
+        print()
+
+    print("Portfolio Metrics:")
+    print(f"CAGR: {cagr(portfolio_eq):.2%}")
+    print(f"MaxDD: {max_drawdown(portfolio_eq):.2%}")
+    print(f"Sharpe: {sharpe_ratio(portfolio_eq):.2f}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/strategies/funding_carry.py
+++ b/strategies/funding_carry.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from backtests.core import Strategy
+from utils.funding import minutes_to_settlement, predicted_funding
+
+
+class FundingCarry(Strategy):
+    """Carry strategy based on predicted funding."""
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        mark = df[["close"]].copy()
+        idx = df[["index_close"]].rename(columns={"index_close": "close"})
+        pred = predicted_funding(mark, idx)
+        minutes = df.index.map(lambda ts: minutes_to_settlement(int(ts.timestamp() * 1000)))
+        signal = pd.Series(0, index=df.index)
+        cond_short = (pred > 0.003) & (minutes >= 5)
+        cond_long = (pred < -0.003) & (minutes >= 5)
+        signal[cond_short] = -1
+        signal[cond_long] = 1
+        signal[minutes <= 3] = 0
+        return signal

--- a/strategies/vol_breakout.py
+++ b/strategies/vol_breakout.py
@@ -2,10 +2,26 @@ import pandas as pd
 from backtests.core import Strategy
 
 class VolBreakout(Strategy):
-    def __init__(self, lookback=30, range_threshold=0.0015, breakout_threshold=0.0010):
+    """Simple volatility breakout strategy."""
+
+    def __init__(self, lookback=15, range_threshold=0.10, breakout_threshold=0.05, risk_mult=1.0):
+        """Initialize breakout parameters.
+
+        Parameters
+        ----------
+        lookback : int
+            Rolling high/low lookback in minutes.
+        range_threshold : float
+            Minimum range relative to low price to activate breakout.
+        breakout_threshold : float
+            Breakout distance from the high/low.
+        risk_mult : float
+            Multiplier applied to position size.
+        """
         self.lookback = lookback
         self.range_threshold = range_threshold
         self.breakout_threshold = breakout_threshold
+        self.risk_mult = risk_mult
 
     def generate_signals(self, df: pd.DataFrame) -> pd.Series:
         high_roll = df['high'].shift(1).rolling(self.lookback).max()

--- a/utils/funding.py
+++ b/utils/funding.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+
+def minutes_to_settlement(ts_ms: int) -> int:
+    """Return minutes until the next 8h funding settlement."""
+    ts = pd.Timestamp(ts_ms, unit="ms", tz="UTC")
+    next_settlement = ts.floor("8H") + pd.Timedelta(hours=8)
+    return int((next_settlement - ts).total_seconds() // 60)
+
+
+def predicted_funding(mark_df: pd.DataFrame, index_df: pd.DataFrame) -> pd.Series:
+    """Calculate predicted funding rate from mark and index price series."""
+    premium = (mark_df["close"] - index_df["close"]) / index_df["close"]
+    return premium.clip(-0.0075, 0.0075)


### PR DESCRIPTION
## Summary
- add funding-carry strategy with predicted funding helpers
- introduce PortfolioSimulator and helper `run_portfolio`
- update vol_breakout defaults and support risk multiplier
- update run_backtest to handle risk multiplier and funding data
- support portfolio backtests via new CLI `run_portfolio.py`
- add funding utilities
- clean up db connection usage
- document new features in README

## Testing
- `python -m py_compile utils/funding.py strategies/funding_carry.py backtests/core.py backtests/run_backtest.py run_portfolio.py run_ingest.py strategies/vol_breakout.py`