### PR TITLE
Enable vol breakout and silence pandas warnings

### DIFF
--- a/backtests/run_backtest.py
+++ b/backtests/run_backtest.py
@@ -1,8 +1,15 @@
 import argparse
 from importlib import import_module
+import warnings
 import pandas as pd
 from backtests.core import cagr, max_drawdown, sharpe_ratio, win_rate, payoff_ratio
 from utils.db import db_conn
+
+warnings.filterwarnings(
+    "ignore",
+    message=".*read_sql.*",
+    category=FutureWarning,
+)
 
 
 def load_data(conn, symbol: str, start: str, end: str, with_index: bool = False) -> pd.DataFrame:

--- a/strategies/vol_breakout.py
+++ b/strategies/vol_breakout.py
@@ -1,10 +1,12 @@
 import pandas as pd
 from backtests.core import Strategy
 
+DEFAULT_RISK_MULT = 1.0
+
 class VolBreakout(Strategy):
     """Simple volatility breakout strategy."""
 
-    def __init__(self, lookback=15, range_threshold=0.10, breakout_threshold=0.05, risk_mult=1.0):
+    def __init__(self, lookback=15, range_threshold=0.10, breakout_threshold=0.05, risk_mult=DEFAULT_RISK_MULT):
         """Initialize breakout parameters.
 
         Parameters

--- a/tests/test_vol_breakout.py
+++ b/tests/test_vol_breakout.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from strategies.vol_breakout import VolBreakout, DEFAULT_RISK_MULT
+
+def test_default_risk_mult():
+    assert DEFAULT_RISK_MULT == 1.0
+
+
+def test_generate_signals_produces_signal():
+    # create sample data around Feb 1 2024
+    index = pd.date_range('2024-02-01', periods=20, freq='1min')
+    data = {
+        'open':  [90]*15 + [110, 111, 112, 113, 114],
+        'high':  [100]*15 + [120, 121, 122, 123, 124],
+        'low':   [90]*15 + [109, 110, 111, 112, 113],
+        'close': [95]*15 + [110, 112, 113, 114, 115],
+    }
+    df = pd.DataFrame(data, index=index)
+    strat = VolBreakout()
+    signals = strat.generate_signals(df)
+    assert (signals != 0).any()

--- a/utils/funding.py
+++ b/utils/funding.py
@@ -4,7 +4,7 @@ import pandas as pd
 def minutes_to_settlement(ts_ms: int) -> int:
     """Return minutes until the next 8h funding settlement."""
     ts = pd.Timestamp(ts_ms, unit="ms", tz="UTC")
-    next_settlement = ts.floor("8H") + pd.Timedelta(hours=8)
+    next_settlement = ts.floor("8h") + pd.Timedelta(hours=8)
     return int((next_settlement - ts).total_seconds() // 60)
 
 


### PR DESCRIPTION
## Summary
- expose `DEFAULT_RISK_MULT` in `vol_breakout`
- ensure portfolio assigns a minimum weight
- silence read_sql deprecation warnings
- use `.ffill()` instead of deprecated call
- adjust funding timestamp floor call
- add unit tests for vol_breakout

## Testing
- `pytest -q` *(fails: No module named 'pandas')*