### PR TITLE
Fix vol_breakout defaults & CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ python -m backtests.run_backtest \
        --strategy vol_breakout \
        --start 2024-11-20 \
        --end   2024-11-27 \
+       --range-thr 0.001 \
+       --breakout-thr 0.0005 \
        --risk-mult 1.0
 ```
 

--- a/backtests/core.py
+++ b/backtests/core.py
@@ -163,6 +163,8 @@ class PortfolioSimulator:
         trades_all = []
         for name, symbol, strat, df in self.strategies:
             trades, equity = strat.simulate(df)
+            if len(trades) == 0:
+                equity = pd.Series(dtype=float)
             kelly = kelly_fraction(trades)
             weight = kelly * self.risk_scale
             if weight == 0:

--- a/backtests/run_backtest.py
+++ b/backtests/run_backtest.py
@@ -47,7 +47,12 @@ def main():
     parser.add_argument('--strategy', required=True)
     parser.add_argument('--start', required=True)
     parser.add_argument('--end', required=True)
-    parser.add_argument('--risk-mult', type=float, default=1.0, help='Risk multiplier for position size')
+    parser.add_argument('--risk-mult', type=float, default=1.0,
+                        help='Risk multiplier for position size')
+    parser.add_argument('--range-thr', type=float, default=0.001,
+                        help='Range threshold as decimal percentage')
+    parser.add_argument('--breakout-thr', type=float, default=0.0005,
+                        help='Breakout threshold as decimal percentage')
     args = parser.parse_args()
 
     conn = db_conn()
@@ -56,7 +61,13 @@ def main():
 
     module = import_module(f"strategies.{args.strategy}")
     cls = getattr(module, ''.join([p.capitalize() for p in args.strategy.split('_')]))
-    if 'risk_mult' in cls.__init__.__code__.co_varnames:
+    if args.strategy == 'vol_breakout':
+        strat = cls(
+            range_threshold=args.range_thr,
+            breakout_threshold=args.breakout_thr,
+            risk_mult=args.risk_mult,
+        )
+    elif 'risk_mult' in cls.__init__.__code__.co_varnames:
         strat = cls(risk_mult=args.risk_mult)
     else:
         strat = cls()


### PR DESCRIPTION
## Summary
- ensure `vol_breakout` works without OHLC columns
- scale breakout thresholds to decimal percentages
- expose breakout thresholds in `run_backtest`
- return empty equity for strategies with no trades
- update example usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*