### PR TITLE
Add index price handling for funding carry in live bot

### DIFF
--- a/tests/test_bybit_utils.py
+++ b/tests/test_bybit_utils.py
@@ -1,4 +1,26 @@
-from utils.bybit import base_url
+from utils.bybit import base_url, get_index_price
+
+
+class DummyResponse:
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"result": {"list": [{"indexPrice": "123.45"}]}}
+
+
+def test_get_index_price(monkeypatch):
+    captured = {}
+
+    def fake_get(url, params=None, timeout=10):
+        captured["url"] = url
+        captured["params"] = params
+        return DummyResponse()
+
+    monkeypatch.setattr("utils.bybit.requests.get", fake_get)
+    price = get_index_price("BTCUSDT")
+    assert price == 123.45
+    assert captured["url"].endswith("/v5/market/tickers")
 
 
 def test_base_url():

--- a/utils/bybit.py
+++ b/utils/bybit.py
@@ -25,6 +25,16 @@ def get_mark_price(symbol: str, net: str = "testnet") -> float:
     return float(data["result"]["list"][0]["markPrice"])
 
 
+def get_index_price(symbol: str, net: str = "testnet") -> float:
+    """Return the current index price for a symbol."""
+    url = base_url(net) + "/v5/market/tickers"
+    params = {"category": "linear", "symbol": symbol}
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    return float(data["result"]["list"][0]["indexPrice"])
+
+
 def _auth_params(key: str, secret: str, params: dict) -> dict:
     ts = str(int(time.time() * 1000))
     recv = "5000"


### PR DESCRIPTION
## Summary
- support retrieving Bybit index price
- feed mark and index prices to `FundingCarry` when running live
- update tests for new `get_index_price` wrapper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*